### PR TITLE
Add float support scanf necessary for spindle linearization

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -107,6 +107,9 @@ build_flags =
   -Wl,-u,_printf_float
   -I lwip/src/include
   -I networking/wiznet
+    # Floating point support for scanf, required for Spindle Linearization
+  -Wl,-u,_scanf_float
+
 lib_deps =
   boards
   bluetooth


### PR DESCRIPTION
- including line from latest platformio.tpl update to enable float support in scanf necessary for functioning of spindle linearization (specifically to allow setting non-null values for parameters $66-$69)