### PR TITLE
Add pwm capability to AuxOutput/Mist/Coolant pins on FlexiHAL

### DIFF
--- a/Src/pwm.c
+++ b/Src/pwm.c
@@ -32,54 +32,83 @@ typedef struct {
 // .en = timerCCEN(CH, ), .pol = timerCCP(CH, ), .ois = timerCR2OIS(CH, ), .ocm = timerOCM(CCR, CH), .ocmc = timerOCM(CCR, CH)
 
 static const pwm_signal_t pwm_pin[] = {
-#if !ETHERNET_ENABLE
-    {
+// #if !ETHERNET_ENABLE
+/*     {
         .port = GPIOA, .pin = 7, .timer = timer(1), .ccr = &timerCCR(1, 1), .ccmr = &timerCCMR(1, 1), .af = timerAF(1, 1),
         .en = timerCCEN(1, N), .pol = timerCCP(1, N), .ois = timerCR2OIS(1, N), .ocm = timerOCM(1, 1), .ocmc = timerOCM(1, 1)
-    },
-#endif
+    }, */
+// #endif
+    //SPINDLE PWM
     {
         .port = GPIOA, .pin = 8, .timer = timer(1), .ccr = &timerCCR(1, 1), .ccmr = &timerCCMR(1, 1), .af = timerAF(1, 1),
         .en = timerCCEN(1, ), .pol = timerCCP(1, ), .ois = timerCR2OIS(1, ), .ocm = timerOCM(1, 1), .ocmc = timerOCM(1, 1)
     },
-    {
+/*     {
         .port = GPIOB, .pin = 0, .timer = timer(1), .ccr = &timerCCR(1, 2), .ccmr = &timerCCMR(1, 1), .af = timerAF(1, 1),
         .en = timerCCEN(2, N), .pol = timerCCP(2, N), .ois = timerCR2OIS(2, N), .ocm = timerOCM(1, 2), .ocmc = timerOCM(1, 2)
-    },
+    }, */
 #if !((SPINDLE_ENCODER_ENABLE && RPM_TIMER_N == 2) || (PPI_ENABLE && PPI_TIMER_N == 2) || (STEP_INJECT_ENABLE && PULSE2_TIMER_N == 2))
+    //STEP_X
     {
         .port = GPIOA, .pin = 3, .timer = timer(2), .ccr = &timerCCR(2, 4), .ccmr = &timerCCMR(2, 2), .af = timerAF(2, 1),
         .en = timerCCEN(4, ), .pol = timerCCP(4, ), .ois = timerCR2OIS(4, ), .ocm = timerOCM(2, 4), .ocmc = timerOCM(2, 4)
     },
+    //X_LIM
     {
         .port = GPIOA, .pin = 5, .timer = timer(2), .ccr = &timerCCR(2, 1), .ccmr = &timerCCMR(2, 1), .af = timerAF(2, 1),
         .en = timerCCEN(1, ), .pol = timerCCP(1, ), .ois = timerCR2OIS(1,), .ocm = timerOCM(1, 1), .ocmc = timerOCM(1, 1)
     },
+    //SPINDLE ENABLE
     {
         .port = GPIOB, .pin = 2, .timer = timer(2), .ccr = &timerCCR(1, 4), .ccmr = &timerCCMR(1, 1), .af = timerAF(1, 1),
         .en = timerCCEN(4, ), .pol = timerCCP(4, ), .ois = timerCR2OIS(4, ), .ocm = timerOCM(2, 4), .ocmc = timerOCM(2, 4)
     },
+    //SPINDLE DIRECTION
     {
         .port = GPIOB, .pin = 3, .timer = timer(2), .ccr = &timerCCR(1, 2), .ccmr = &timerCCMR(1, 1), .af = timerAF(1, 1),
         .en = timerCCEN(2, ), .pol = timerCCP(2, ), .ois = timerCR2OIS(2, ), .ocm = timerOCM(1, 2), .ocmc = timerOCM(1, 2)
     },
+    //KPSTR
     {
         .port = GPIOB, .pin = 10, .timer = timer(2), .ccr = &timerCCR(2, 3), .ccmr = &timerCCMR(2, 2), .af = timerAF(2, 1),
         .en = timerCCEN(3, ), .pol = timerCCP(3, ), .ois = timerCR2OIS(3, ), .ocm = timerOCM(2, 3), .ocmc = timerOCM(2, 3)
     },
 #endif
 #if !((SPINDLE_ENCODER_ENABLE && RPM_COUNTER_N == 3) || (STEP_INJECT_ENABLE && PULSE2_TIMER_N == 3))
+    //SPI_CK
     {
         .port = GPIOB, .pin = 4, .timer = timer(3), .ccr = &timerCCR(3, 1), .ccmr = &timerCCMR(3, 1), .af = timerAF(3, 2),
         .en = timerCCEN(1, ), .pol = timerCCP(1, ), .ois = timerCR2OIS(1, ), .ocm = timerOCM(1, 1), .ocmc = timerOCM(1, 1)
     },
+    //SCL
     {
         .port = GPIOC, .pin = 6, .timer = timer(3), .ccr = &timerCCR(3, 1), .ccmr = &timerCCMR(3, 1), .af = timerAF(3, 2),
-        .en = timerCCEN(1, ), .pol = timerCCP(1, ), .ois = timerCR2OIS(3, ), .ocm = timerOCM(1, 1), .ocmc = timerOCM(1, 1)
+        .en = timerCCEN(1, ), .pol = timerCCP(1, ), .ois = timerCR2OIS(1, ), .ocm = timerOCM(1, 1), .ocmc = timerOCM(1, 1)
     },
+    //FD_HLD    
     {
         .port = GPIOC, .pin = 8, .timer = timer(3), .ccr = &timerCCR(3, 3), .ccmr = &timerCCMR(3, 2), .af = timerAF(3, 2),
         .en = timerCCEN(3, ), .pol = timerCCP(3, ), .ois = timerCR2OIS(3, ), .ocm = timerOCM(2, 3), .ocmc = timerOCM(2, 3)
+    },
+    //AUXOUT3
+    {
+        .port = GPIOA, .pin = 6, .timer = timer(3), .ccr = &timerCCR(3, 1), .ccmr = &timerCCMR(3, 1), .af = timerAF(3, 2),
+        .en = timerCCEN(1, ), .pol = timerCCP(1, ), .ois = timerCR2OIS(1, ), .ocm = timerOCM(1, 1), .ocmc = timerOCM(1, 1)
+    },
+    //MIST
+    {
+        .port = GPIOA, .pin = 7, .timer = timer(3), .ccr = &timerCCR(3, 2), .ccmr = &timerCCMR(3, 1), .af = timerAF(3, 2),
+        .en = timerCCEN(2, ), .pol = timerCCP(2, ), .ois = timerCR2OIS(2, ), .ocm = timerOCM(1, 2), .ocmc = timerOCM(1, 2)
+    },
+    //AUXOUT1
+    {
+        .port = GPIOB, .pin = 0, .timer = timer(3), .ccr = &timerCCR(3, 3), .ccmr = &timerCCMR(3, 2), .af = timerAF(3, 2),
+        .en = timerCCEN(3, ), .pol = timerCCP(3, ), .ois = timerCR2OIS(3, ), .ocm = timerOCM(2, 3), .ocmc = timerOCM(2, 3)
+    },
+    //COOLANT
+    {
+        .port = GPIOC, .pin = 9, .timer = timer(3), .ccr = &timerCCR(3, 4), .ccmr = &timerCCMR(3, 2), .af = timerAF(3, 2),
+        .en = timerCCEN(4, ), .pol = timerCCP(4, ), .ois = timerCR2OIS(4, ), .ocm = timerOCM(2, 4), .ocmc = timerOCM(2, 4)
     },
 #endif
     {
@@ -90,6 +119,7 @@ static const pwm_signal_t pwm_pin[] = {
         .port = GPIOE, .pin = 6, .timer = timer(9), .ccr = &timerCCR(9, 2), .ccmr = &timerCCMR(9, 1), .af = timerAF(9, 3),
         .en = timerCCEN(2, ), .pol = timerCCP(2, ), .ois = timerCR2OIS(2, ), .ocm = timerOCM(1, 2), .ocmc = timerOCM(1, 2)
     },
+    //Y_LIM
     {
         .port = GPIOB, .pin = 9, .timer = timer(11), .ccr = &timerCCR(11, 1), .ccmr = &timerCCMR(11, 1), .af = timerAF(11, 3),
         .en = timerCCEN(1, ), .pol = timerCCP(1, ), .ois = timerCR2OIS(1, ), .ocm = timerOCM(1, 1), .ocmc = timerOCM(1, 1)

--- a/Src/pwm.c
+++ b/Src/pwm.c
@@ -32,21 +32,23 @@ typedef struct {
 // .en = timerCCEN(CH, ), .pol = timerCCP(CH, ), .ois = timerCR2OIS(CH, ), .ocm = timerOCM(CCR, CH), .ocmc = timerOCM(CCR, CH)
 
 static const pwm_signal_t pwm_pin[] = {
-// #if !ETHERNET_ENABLE
-/*     {
+#if !ETHERNET_ENABLE && !BOARD_FLEXI_HAL
+    {
         .port = GPIOA, .pin = 7, .timer = timer(1), .ccr = &timerCCR(1, 1), .ccmr = &timerCCMR(1, 1), .af = timerAF(1, 1),
         .en = timerCCEN(1, N), .pol = timerCCP(1, N), .ois = timerCR2OIS(1, N), .ocm = timerOCM(1, 1), .ocmc = timerOCM(1, 1)
-    }, */
-// #endif
+    },
+#endif
     //SPINDLE PWM
     {
         .port = GPIOA, .pin = 8, .timer = timer(1), .ccr = &timerCCR(1, 1), .ccmr = &timerCCMR(1, 1), .af = timerAF(1, 1),
         .en = timerCCEN(1, ), .pol = timerCCP(1, ), .ois = timerCR2OIS(1, ), .ocm = timerOCM(1, 1), .ocmc = timerOCM(1, 1)
     },
-/*     {
+#if !BOARD_FLEXI_HAL
+    {
         .port = GPIOB, .pin = 0, .timer = timer(1), .ccr = &timerCCR(1, 2), .ccmr = &timerCCMR(1, 1), .af = timerAF(1, 1),
         .en = timerCCEN(2, N), .pol = timerCCP(2, N), .ois = timerCR2OIS(2, N), .ocm = timerOCM(1, 2), .ocmc = timerOCM(1, 2)
-    }, */
+    },
+#endif
 #if !((SPINDLE_ENCODER_ENABLE && RPM_TIMER_N == 2) || (PPI_ENABLE && PPI_TIMER_N == 2) || (STEP_INJECT_ENABLE && PULSE2_TIMER_N == 2))
     //STEP_X
     {
@@ -90,6 +92,8 @@ static const pwm_signal_t pwm_pin[] = {
         .port = GPIOC, .pin = 8, .timer = timer(3), .ccr = &timerCCR(3, 3), .ccmr = &timerCCMR(3, 2), .af = timerAF(3, 2),
         .en = timerCCEN(3, ), .pol = timerCCP(3, ), .ois = timerCR2OIS(3, ), .ocm = timerOCM(2, 3), .ocmc = timerOCM(2, 3)
     },
+#endif
+#if !((SPINDLE_ENCODER_ENABLE && RPM_COUNTER_N == 3) || (STEP_INJECT_ENABLE && PULSE2_TIMER_N == 3)) && BOARD_FLEXI_HAL
     //AUXOUT3
     {
         .port = GPIOA, .pin = 6, .timer = timer(3), .ccr = &timerCCR(3, 1), .ccmr = &timerCCMR(3, 1), .af = timerAF(3, 2),


### PR DESCRIPTION
Added timer and alternate function specifications for additional pins that might be reconfigured for PWM output on the FlexiHAL Board. 

Two existing pin definitions using timer 1 (GPIO A Pin 7 / Mist and GPIO B Pin 0 / AuxOut1) were moved to timer 3, to avoid conflicts with the default spindle PWM pin (GPIO A Pin 8). Two additional pin definitions were also provided on timer 3 (GPIO A Pin 6 / AuxOut3 and GPIO C Pin 9 / Coolant). A suspected typo was also fixed in the pin definition for GPIO C Pin 6 / SCL. All other pin definitions were unchanged but comments were added in some places to specify the default Flexi pin assignment.

Functionality test was performed using GPIOA Pin 7 (Mist), and results were as expected. Note that to use this pin for aux output it was necessary to reassign the mist pin and include the following lines in the flexi_hal_map.h:

#define AUXOUTPUT0_PWM_PORT     GPIOA
#define AUXOUTPUT0_PWM_PIN        7
